### PR TITLE
Handle some edge cases in various OpenAPI schemas

### DIFF
--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -1053,19 +1053,24 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 		return &pschema.TypeSpec{Type: "string"}, false, nil
 	}
 
+	valType := propSchema.Value.Type
+	if valType == nil && len(propSchema.Value.AnyOf) == 1 {
+		valType = propSchema.Value.AnyOf[0].Value.Type
+	}
+
 	// All other types.
 	switch {
-	case propSchema.Value.Type.Is(openapi3.TypeInteger):
+	case valType.Is(openapi3.TypeInteger):
 		return &pschema.TypeSpec{Type: "integer"}, false, nil
-	case propSchema.Value.Type.Is(openapi3.TypeString):
+	case valType.Is(openapi3.TypeString):
 		return &pschema.TypeSpec{Type: "string"}, false, nil
-	case propSchema.Value.Type.Is(openapi3.TypeBoolean):
+	case valType.Is(openapi3.TypeBoolean):
 		return &pschema.TypeSpec{Type: "boolean"}, false, nil
-	case propSchema.Value.Type.Is(openapi3.TypeNumber):
+	case valType.Is(openapi3.TypeNumber):
 		return &pschema.TypeSpec{Type: "number"}, false, nil
-	case propSchema.Value.Type.Is(openapi3.TypeObject):
+	case valType.Is(openapi3.TypeObject):
 		return &pschema.TypeSpec{Ref: "pulumi.json#/Any"}, false, nil
-	case propSchema.Value.Type.Is(openapi3.TypeArray):
+	case valType.Is(openapi3.TypeArray):
 		elementType, _, err := ctx.propertyTypeSpec(parentName+"Item", *propSchema.Value.Items)
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "generating array item type (parentName: %s)", parentName)

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -1103,7 +1103,7 @@ func (ctx *resourceContext) genProperties(parentName string, typeSchema openapi3
 		var err error
 
 		if value.Value.AdditionalProperties.Has != nil {
-			allowed := *value.Value.AdditionalProperties.Has
+			allowed := *value.Value.AdditionalProperties.Has && len(value.Value.Properties) > 0
 			if allowed {
 				// There's only ever going to be a single property
 				// in the map, which will either have an inlined

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -1048,11 +1048,6 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 		}
 	}
 
-	// OpenAI shenanigans.
-	if val, has := propSchema.Value.Extensions["x-oaiTypeLabel"]; has && val == "string" {
-		return &pschema.TypeSpec{Type: "string"}, false, nil
-	}
-
 	valType := propSchema.Value.Type
 	if valType == nil && len(propSchema.Value.AnyOf) == 1 {
 		valType = propSchema.Value.AnyOf[0].Value.Type

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -1048,6 +1048,11 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 		}
 	}
 
+	// OpenAI shenanigans.
+	if val, has := propSchema.Value.Extensions["x-oaiTypeLabel"]; has && val == "string" {
+		return &pschema.TypeSpec{Type: "string"}, false, nil
+	}
+
 	// All other types.
 	switch {
 	case propSchema.Value.Type.Is(openapi3.TypeInteger):


### PR DESCRIPTION
Hi @praneetloke! I was playing around with pulschema - concretely, plugging it directly into pulumi-go-provider - and while trying it out on various schemas, I encountered some issues that these commits fix or workaround. I hope the individual commits should be self-explanatory:
- **Check for OpenAI's x-oaiTypeLabel extension**
- **When there's a single AnyOf type, use it as the property's type**
- **Protect against panic when there are no additional properties**

BTW, in the end my main problem turned out to be `$ref` references to types. For instance, when we try to determine the GET response type:
```go
jsonReq := pathItem.Get.Responses.Status(200).Value.Content.Get(jsonMimeType)
```

In the Azure spec, `jsonMimeType` is not used as far as I could see. Instead, the response has an Extension "schema", which is a `$ref` to, e.g., `#/definitions/OperationListResult`. I couldn't see a way to load this `$ref` to obtain the actual schema of the type to work with.