### PR TITLE
Ensure discriminated resource names are prefixed with the parent resource name

### DIFF
--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -168,11 +168,12 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 					for _, ref := range resourceType.Discriminator.Mapping {
 						schemaName := strings.TrimPrefix(ref, componentsSchemaRefPrefix)
 						dResource := o.Doc.Components.Schemas[schemaName]
+						parentResourceName := getResourceTitleFromOperationID(pathItem.Get.OperationID, http.MethodGet, o.OperationIdsHaveTypeSpecNamespace)
 						title := getResourceTitleFromRequestSchema(schemaName, dResource)
-						typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, title)
+						typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, parentResourceName+title)
 						setReadOperationMapping(typeToken)
 
-						funcName := "get" + dResource.Value.Title
+						funcName := "get" + title
 						funcTypeToken := o.Pkg.Name + ":" + module + ":" + funcName
 						getterFuncSpec := o.genGetFunc(*pathItem, *dResource, module, funcName)
 						o.Pkg.Functions[funcTypeToken] = getterFuncSpec
@@ -180,6 +181,10 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 					}
 				} else {
 					resourceName := getResourceTitleFromOperationID(pathItem.Get.OperationID, http.MethodGet, o.OperationIdsHaveTypeSpecNamespace)
+					// HACK! Use the singular version of the resource name
+					// where the current operation is fetching a single
+					// item instead of a list.
+					resourceName = strings.TrimSuffix(resourceName, "s")
 
 					// The resource needs to be read from the cloud provider API,
 					// so we should map this "read" endpoint for this resource.
@@ -258,8 +263,9 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 
 				for _, n := range schemaNames {
 					dResource := o.Doc.Components.Schemas[n]
+					parentResourceName := getResourceTitleFromOperationID(pathItem.Patch.OperationID, http.MethodPatch, o.OperationIdsHaveTypeSpecNamespace)
 					resourceName := getResourceTitleFromRequestSchema(n, dResource)
-					typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, resourceName)
+					typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, parentResourceName+resourceName)
 					setUpdateOperationMapping(typeToken)
 				}
 			} else {
@@ -296,8 +302,9 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 				for _, ref := range resourceType.Discriminator.Mapping {
 					schemaName := strings.TrimPrefix(ref, componentsSchemaRefPrefix)
 					dResource := o.Doc.Components.Schemas[schemaName]
+					parentResourceName := getResourceTitleFromOperationID(pathItem.Put.OperationID, http.MethodPut, o.OperationIdsHaveTypeSpecNamespace)
 					resourceName := getResourceTitleFromRequestSchema(schemaName, dResource)
-					typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, resourceName)
+					typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, parentResourceName+resourceName)
 					setPutOperationMapping(typeToken)
 				}
 			} else {
@@ -345,8 +352,9 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 					for _, ref := range resourceType.Discriminator.Mapping {
 						schemaName := strings.TrimPrefix(ref, componentsSchemaRefPrefix)
 						dResource := o.Doc.Components.Schemas[schemaName]
+						parentResourceName := getResourceTitleFromOperationID(pathItem.Delete.OperationID, http.MethodDelete, o.OperationIdsHaveTypeSpecNamespace)
 						resourceName := getResourceTitleFromRequestSchema(schemaName, dResource)
-						typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, resourceName)
+						typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, parentResourceName+resourceName)
 						setDeleteOperationMapping(typeToken)
 					}
 				} else {


### PR DESCRIPTION
Endpoint paths that use a discriminator need to have their resource names prefixed with the parent resource. Note that the "parent resource" here just means the base resource name. For example, take the following endpoint `/services`. If there is a discriminator mapping like this:

```
discriminator:
  web: "#/components/schemas/web"
  static_site: "#/components/schemas/staticsite"
```

Then the "web" resource should be named `ServicesWeb` or `ServicesStaticSite`. This ensures that resources are "namespaced" by their base resource name.

**Note**: This was already the case when [handling POST request method](https://github.com/cloudy-sky-software/pulschema/blob/main/pkg/openapi.go#L610) but the same type of naming was needed in the other request methods as well, which is what this PR does.