### PR TITLE
Consider path parameters common to all operations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
         "build.env": {
             "GOPRIVATE": "github.com/cloudy-sky-software/pulumi-render,github.com/cloudy-sky-software/pulschema"
         }
+    },
+    "yaml.schemas": {
+        "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json": [
+            "**/testdata/*.yml"
+        ]
     }
 }

--- a/pkg/common_path_params_test.go
+++ b/pkg/common_path_params_test.go
@@ -1,0 +1,40 @@
+package pkg
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCommonPathParams tests if path params that are
+// common to all operations are considered.
+func TestCommonPathParams(t *testing.T) {
+	mustReadTestOpenAPIDoc(t, filepath.Join("testdata", "common_path_params_openapi.yml"))
+
+	openAPICtx := &OpenAPIContext{
+		Doc: *testOpenAPIDoc,
+		Pkg: &testPulumiPkg,
+	}
+
+	csharpNamespaces := map[string]string{
+		"": "Provider",
+	}
+
+	_, _, err := openAPICtx.GatherResourcesFromAPI(csharpNamespaces)
+	assert.Nil(t, err)
+
+	subResource, ok := testPulumiPkg.Resources["fake-package:fakeresource/v2:SubResource"]
+	assert.Truef(t, ok, "Expected to find a resource called SubResource: %v", testPulumiPkg.Resources)
+
+	// Ensure that the input properties for the resource contains
+	// the expected id property.
+	assert.Contains(t, subResource.InputProperties, "id")
+
+	// Ensure that the "get" func also contains the id
+	// as an input properties.
+	getFunc, ok := testPulumiPkg.Functions["fake-package:fakeresource/v2:listSubResources"]
+	assert.Truef(t, ok, "Expected to find a list func listSubResources: %v", testPulumiPkg.Functions)
+	assert.NotNil(t, getFunc.Inputs)
+	assert.Contains(t, getFunc.Inputs.Properties, "id")
+}

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -371,6 +371,10 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 
 		contract.Assertf(pathItem.Post.OperationID != "", "operationId is missing for path POST %s", currentPath)
 
+		// TODO: Make request body optional for POST requests.
+		// Such requests are used for ad hoc operations on
+		// resources.
+
 		jsonReq := pathItem.Post.RequestBody.Value.Content.Get(jsonMimeType)
 		if jsonReq.Schema.Value == nil {
 			return nil, o.Doc, errors.Errorf("path %s has no api schema definition for post method", currentPath)
@@ -954,6 +958,7 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 		// which are actually just simple types.
 		if !typeSchema.Value.Type.Is(openapi3.TypeObject) &&
 			len(typeSchema.Value.Properties) == 0 &&
+			len(typeSchema.Value.OneOf) == 0 &&
 			len(typeSchema.Value.AllOf) == 0 {
 			return &pschema.TypeSpec{
 				Type: typeSchema.Value.Type.Slice()[0],

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -953,7 +953,6 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 	if propSchema.Ref != "" && !propSchema.Value.Type.Is(openapi3.TypeArray) && len(propSchema.Value.Enum) == 0 {
 		schemaName := strings.TrimPrefix(propSchema.Ref, componentsSchemaRefPrefix)
 		typName := ToPascalCase(schemaName)
-		typName = sanitizeResourceTitle(typName)
 		tok := fmt.Sprintf("%s:%s:%s", ctx.pkg.Name, ctx.mod, typName)
 
 		typeSchema, ok := ctx.openapiComponents.Schemas[schemaName]
@@ -974,14 +973,14 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 			}, false, nil
 		}
 
-		if len(typeSchema.Value.OneOf) > 0 {
-			return ctx.propertyTypeSpec(typName, *typeSchema)
-		}
-
 		newType := !ctx.visitedTypes.Has(tok)
 
 		if newType {
 			ctx.visitedTypes.Add(tok)
+
+			if len(typeSchema.Value.OneOf) > 0 {
+				return ctx.propertyTypeSpec(typName, *typeSchema)
+			}
 
 			specs, requiredSpecs, err := ctx.genProperties(typName, *typeSchema.Value)
 			if err != nil {

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -973,14 +973,14 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 			}, false, nil
 		}
 
+		if len(typeSchema.Value.OneOf) > 0 {
+			return ctx.propertyTypeSpec(typName, *typeSchema)
+		}
+
 		newType := !ctx.visitedTypes.Has(tok)
 
 		if newType {
 			ctx.visitedTypes.Add(tok)
-
-			if len(typeSchema.Value.OneOf) > 0 {
-				return ctx.propertyTypeSpec(typName, *typeSchema)
-			}
 
 			specs, requiredSpecs, err := ctx.genProperties(typName, *typeSchema.Value)
 			if err != nil {

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -953,6 +953,7 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 	if propSchema.Ref != "" && !propSchema.Value.Type.Is(openapi3.TypeArray) && len(propSchema.Value.Enum) == 0 {
 		schemaName := strings.TrimPrefix(propSchema.Ref, componentsSchemaRefPrefix)
 		typName := ToPascalCase(schemaName)
+		typName = sanitizeResourceTitle(typName)
 		tok := fmt.Sprintf("%s:%s:%s", ctx.pkg.Name, ctx.mod, typName)
 
 		typeSchema, ok := ctx.openapiComponents.Schemas[schemaName]
@@ -1130,10 +1131,6 @@ func (ctx *resourceContext) genProperties(parentName string, typeSchema openapi3
 	requiredSpecs := codegen.NewStringSet()
 
 	for _, name := range codegen.SortedKeys(typeSchema.Properties) {
-		if name == "id" {
-			continue
-		}
-
 		value := typeSchema.Properties[name]
 		sdkName := ToSdkName(name)
 
@@ -1201,10 +1198,6 @@ func (ctx *resourceContext) genProperties(parentName string, typeSchema openapi3
 	}
 
 	for _, name := range typeSchema.Required {
-		if name == "id" {
-			continue
-		}
-
 		sdkName := ToSdkName(name)
 		if sdkName != name {
 			addNameOverride(sdkName, name, ctx.sdkToAPINameMap)

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -953,6 +953,7 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 	if propSchema.Ref != "" && !propSchema.Value.Type.Is(openapi3.TypeArray) && len(propSchema.Value.Enum) == 0 {
 		schemaName := strings.TrimPrefix(propSchema.Ref, componentsSchemaRefPrefix)
 		typName := ToPascalCase(schemaName)
+		typName = sanitizeResourceTitle(typName)
 		tok := fmt.Sprintf("%s:%s:%s", ctx.pkg.Name, ctx.mod, typName)
 
 		typeSchema, ok := ctx.openapiComponents.Schemas[schemaName]
@@ -973,14 +974,14 @@ func (ctx *resourceContext) propertyTypeSpec(parentName string, propSchema opena
 			}, false, nil
 		}
 
+		if len(typeSchema.Value.OneOf) > 0 {
+			return ctx.propertyTypeSpec(typName, *typeSchema)
+		}
+
 		newType := !ctx.visitedTypes.Has(tok)
 
 		if newType {
 			ctx.visitedTypes.Add(tok)
-
-			if len(typeSchema.Value.OneOf) > 0 {
-				return ctx.propertyTypeSpec(typName, *typeSchema)
-			}
 
 			specs, requiredSpecs, err := ctx.genProperties(typName, *typeSchema.Value)
 			if err != nil {

--- a/pkg/resource_naming.go
+++ b/pkg/resource_naming.go
@@ -93,19 +93,9 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 	return resourceTitle
 }
 
-var replaceKeywords = []string{"POST", "Post", "post", "DELETE", "Delete", "delete", "put", "PUT", "Put", "Patch", "PATCH", "patch", "get", "GET", "Get"}
-
-func sanitizeResourceTitle(title string) string {
-	for _, keyword := range replaceKeywords {
-		title = strings.ReplaceAll(title, keyword, "")
-	}
-
-	return title
-}
-
 func getResourceTitleFromRequestSchema(schemaName string, schemaRef *openapi3.SchemaRef) string {
 	if schemaRef.Value.Title != "" {
-		return ToPascalCase(sanitizeResourceTitle(schemaRef.Value.Title))
+		return ToPascalCase(schemaRef.Value.Title)
 	}
 
 	var title string
@@ -122,7 +112,7 @@ func getResourceTitleFromRequestSchema(schemaName string, schemaRef *openapi3.Sc
 		title = result
 	}
 
-	return sanitizeResourceTitle(title)
+	return title
 }
 
 // ensureIDHierarchyInRequestPath ensures that the IDs in the path

--- a/pkg/resource_naming.go
+++ b/pkg/resource_naming.go
@@ -93,9 +93,19 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 	return resourceTitle
 }
 
+var replaceKeywords = []string{"POST", "Post", "post", "DELETE", "Delete", "delete", "put", "PUT", "Put", "Patch", "PATCH", "patch", "get", "GET", "Get"}
+
+func sanitizeResourceTitle(title string) string {
+	for _, keyword := range replaceKeywords {
+		title = strings.ReplaceAll(title, keyword, "")
+	}
+
+	return title
+}
+
 func getResourceTitleFromRequestSchema(schemaName string, schemaRef *openapi3.SchemaRef) string {
 	if schemaRef.Value.Title != "" {
-		return ToPascalCase(schemaRef.Value.Title)
+		return ToPascalCase(sanitizeResourceTitle(schemaRef.Value.Title))
 	}
 
 	var title string
@@ -112,7 +122,7 @@ func getResourceTitleFromRequestSchema(schemaName string, schemaRef *openapi3.Sc
 		title = result
 	}
 
-	return title
+	return sanitizeResourceTitle(title)
 }
 
 // ensureIDHierarchyInRequestPath ensures that the IDs in the path

--- a/pkg/resource_naming.go
+++ b/pkg/resource_naming.go
@@ -93,9 +93,22 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 	return resourceTitle
 }
 
+var replaceKeywords = map[string]string{"POST": "Create", "Post": "Create", "post": "create", "DELETE": "Delete", "Delete": "Delete", "PUT": "Put", "Put": "Put", "Patch": "Patch", "PATCH": "Patch", "GET": "Get", "Get": "Get"}
+
+func sanitizeResourceTitle(title string) string {
+	for match, replaceWith := range replaceKeywords {
+		if strings.Contains(title, match) {
+			title = strings.ReplaceAll(title, match, replaceWith)
+			break
+		}
+	}
+
+	return title
+}
+
 func getResourceTitleFromRequestSchema(schemaName string, schemaRef *openapi3.SchemaRef) string {
 	if schemaRef.Value.Title != "" {
-		return ToPascalCase(schemaRef.Value.Title)
+		return ToPascalCase(sanitizeResourceTitle(schemaRef.Value.Title))
 	}
 
 	var title string
@@ -112,7 +125,7 @@ func getResourceTitleFromRequestSchema(schemaName string, schemaRef *openapi3.Sc
 		title = result
 	}
 
-	return title
+	return sanitizeResourceTitle(title)
 }
 
 // ensureIDHierarchyInRequestPath ensures that the IDs in the path

--- a/pkg/testdata/common_path_params_openapi.yml
+++ b/pkg/testdata/common_path_params_openapi.yml
@@ -1,0 +1,58 @@
+openapi: 3.1.0
+info:
+  title: Fake API
+  version: "2.0"
+servers:
+  - url: https://api.fake.com
+    description: production
+
+components:
+  schemas:
+    a_string_prop:
+      type: string
+    request_object_type:
+      type: object
+      properties:
+        simple_prop:
+          $ref: "#/components/schemas/a_string_prop"
+    response_object_type:
+      type: object
+      properties:
+        another_prop:
+          $ref: "#/components/schemas/a_string_prop"
+
+paths:
+  /v2/fakeResource/{id}/subResource:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: listSubResources
+      responses:
+        "200":
+          description: The response will be a JSON object with a key called `action`.
+          content:
+            application/json:
+              schema:
+                properties:
+                  subResources:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/response_object_type"
+    post:
+      operationId: createSubResource
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/request_object_type"
+      responses:
+        "200":
+          description: The response will be a JSON object with a key called `action`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/response_object_type"

--- a/pkg/testdata/common_path_params_openapi.yml
+++ b/pkg/testdata/common_path_params_openapi.yml
@@ -33,7 +33,7 @@ paths:
       operationId: listSubResources
       responses:
         "200":
-          description: The response will be a JSON object with a key called `action`.
+          description: The response will be a JSON object with a key called `subResources` which is an array of sub-resource items.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Closes #147.

Also ensure that resource or type names extracted from a schema's title are sanitized.