### PR TITLE
Allow providers to pass a list of allowed plural resource names

### DIFF
--- a/pkg/naming.go
+++ b/pkg/naming.go
@@ -84,7 +84,7 @@ func addNameOverride(key, value string, m map[string]string) {
 
 func getSingularNameForResource(resourceName string, allowedPluralNames []string) string {
 	for _, n := range allowedPluralNames {
-		if strings.HasSuffix(resourceName, n) {
+		if !strings.HasSuffix(resourceName, n) {
 			return strings.TrimSuffix(resourceName, "s")
 		}
 	}

--- a/pkg/naming.go
+++ b/pkg/naming.go
@@ -9,6 +9,7 @@ import (
 )
 
 var numbersRegexp = regexp.MustCompile("[0-9]+[_]*[a-zA-Z]+")
+var defaultAllowedPluralResourceNames = []string{"Kubernetes"}
 
 // ToSdkName converts a property or attribute name to the lowerCamelCase convention that
 // is used in Pulumi schema's properties.
@@ -79,4 +80,14 @@ func addNameOverride(key, value string, m map[string]string) {
 	}
 
 	m[key] = value
+}
+
+func getSingularNameForResource(resourceName string, allowedPluralNames []string) string {
+	for _, n := range allowedPluralNames {
+		if !strings.HasSuffix(resourceName, n) {
+			return strings.TrimSuffix(resourceName, "s")
+		}
+	}
+
+	return resourceName
 }

--- a/pkg/naming.go
+++ b/pkg/naming.go
@@ -84,7 +84,7 @@ func addNameOverride(key, value string, m map[string]string) {
 
 func getSingularNameForResource(resourceName string, allowedPluralNames []string) string {
 	for _, n := range allowedPluralNames {
-		if !strings.HasSuffix(resourceName, n) {
+		if strings.HasSuffix(resourceName, n) {
 			return strings.TrimSuffix(resourceName, "s")
 		}
 	}

--- a/pkg/naming.go
+++ b/pkg/naming.go
@@ -82,11 +82,19 @@ func addNameOverride(key, value string, m map[string]string) {
 	m[key] = value
 }
 
+// getSingularNameForResource returns a singular version of a resource name,
+// as long as the name doesn't have one of the valid plural names as its
+// suffix.
 func getSingularNameForResource(resourceName string, allowedPluralNames []string) string {
+	allowPluralName := false
 	for _, n := range allowedPluralNames {
-		if !strings.HasSuffix(resourceName, n) {
-			return strings.TrimSuffix(resourceName, "s")
+		if strings.HasSuffix(resourceName, n) {
+			allowPluralName = true
 		}
+	}
+
+	if !allowPluralName {
+		return strings.TrimSuffix(resourceName, "s")
 	}
 
 	return resourceName

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -30,7 +30,6 @@ const (
 )
 
 var versionRegex = regexp.MustCompile("v[0-9]+[a-z0-9]*")
-var defaultAllowedPluralResourceNames = []string{"Kubernetes"}
 
 // OpenAPIContext represents an OpenAPI spec from which a Pulumi package
 // spec can be extracted.
@@ -65,6 +64,10 @@ type OpenAPIContext struct {
 	// TypeSpecNamespaceSeparator is the separator used in the operationId value.
 	TypeSpecNamespaceSeparator string
 
+	// AllowedPluralResources is a slice of resource names that should not
+	// be converted to their singular version.
+	AllowedPluralResources []string
+
 	// resourceCRUDMap is a map of the Pulumi resource type
 	// token to its CRUD endpoints.
 	resourceCRUDMap map[string]*CRUDOperationsMap
@@ -85,7 +88,8 @@ type OpenAPIContext struct {
 	// to the SDK name used in the Pulumi schema. This can
 	// be used by providers to look-up the value for a path
 	// param in the inputs map.
-	pathParamNameMap map[string]string
+	pathParamNameMap       map[string]string
+	allowedPluralResources []string
 }
 
 type duplicateEnumError struct {
@@ -115,6 +119,8 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 	o.sdkToAPINameMap = make(map[string]string)
 	o.apiToSDKNameMap = make(map[string]string)
 	o.pathParamNameMap = make(map[string]string)
+
+	o.allowedPluralResources = append(o.AllowedPluralResources, defaultAllowedPluralResourceNames...)
 
 	for _, path := range o.Doc.Paths.InMatchingOrder() {
 		pathItem := o.Doc.Paths.Find(path)
@@ -269,6 +275,7 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 				}
 			} else {
 				resourceName := getResourceTitleFromOperationID(pathItem.Patch.OperationID, http.MethodPatch, o.OperationIdsHaveTypeSpecNamespace)
+				resourceName = getSingularNameForResource(resourceName, o.allowedPluralResources)
 				typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, resourceName)
 				setUpdateOperationMapping(typeToken)
 			}
@@ -316,6 +323,7 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 			// to create resources if the endpoint itself requires the ID of the resource.
 			if pathItem.Post == nil && !strings.HasSuffix(currentPath, "}") {
 				resourceName := getResourceTitleFromOperationID(pathItem.Put.OperationID, http.MethodPut, o.OperationIdsHaveTypeSpecNamespace)
+				resourceName = getSingularNameForResource(resourceName, o.allowedPluralResources)
 				parameters := pathItem.Parameters
 				parameters = append(parameters, pathItem.Put.Parameters...)
 				if err := o.gatherResource(currentPath, resourceName, *resourceType, nil /*response type*/, parameters, module); err != nil {
@@ -358,17 +366,13 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 					}
 				} else {
 					resourceName := getResourceTitleFromOperationID(pathItem.Delete.OperationID, http.MethodDelete, o.OperationIdsHaveTypeSpecNamespace)
-					if !strings.HasSuffix(resourceName, "Kubernetes") {
-						resourceName = strings.TrimSuffix(resourceName, "s")
-					}
+					resourceName = getSingularNameForResource(resourceName, o.allowedPluralResources)
 					typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, resourceName)
 					setDeleteOperationMapping(typeToken)
 				}
 			} else {
 				resourceName := getResourceTitleFromOperationID(pathItem.Delete.OperationID, http.MethodDelete, o.OperationIdsHaveTypeSpecNamespace)
-				if !strings.HasSuffix(resourceName, "Kubernetes") {
-					resourceName = strings.TrimSuffix(resourceName, "s")
-				}
+				resourceName = getSingularNameForResource(resourceName, o.allowedPluralResources)
 				typeToken := fmt.Sprintf("%s:%s:%s", o.Pkg.Name, module, resourceName)
 				setDeleteOperationMapping(typeToken)
 			}
@@ -426,9 +430,7 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 		}
 
 		resourceName := getResourceTitleFromOperationID(pathItem.Post.OperationID, http.MethodPost, o.OperationIdsHaveTypeSpecNamespace)
-		if !strings.HasSuffix(resourceName, "Kubernetes") {
-			resourceName = strings.TrimSuffix(resourceName, "s")
-		}
+		resourceName = getSingularNameForResource(resourceName, o.allowedPluralResources)
 
 		resourceRequestType := jsonReq.Schema.Value
 		parameters := pathItem.Parameters

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -30,6 +30,7 @@ const (
 )
 
 var versionRegex = regexp.MustCompile("v[0-9]+[a-z0-9]*")
+var defaultAllowedPluralResourceNames = []string{"Kubernetes"}
 
 // OpenAPIContext represents an OpenAPI spec from which a Pulumi package
 // spec can be extracted.


### PR DESCRIPTION
Resource name suffixes are trimmed of their "s" to join up the various operations. But some resource names are valid in their plural form. For example, while `Databases` is not a valid name for a resource (since it doesn't make sense that one would create multiple databases with one resource) and should be represented in the resources map as `Database`, a resource called `Tags` is likely legal because it could be a resource that allows the user to apply several tags to a resource and so `Tags` should be left alone. Another example is `Kubernetes` which should not be trimmed obviously but that's already part of the default list.