### PR TITLE
feat: Add PUT create resource with path parameter support

### DIFF
--- a/pkg/put_create_resource_with_path_param_test.go
+++ b/pkg/put_create_resource_with_path_param_test.go
@@ -1,0 +1,40 @@
+package pkg
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPutCreateResourceWithPathParam tests creating a resource
+// with a PUT and a path param
+func TestPutCreateResourceWithPathParam(t *testing.T) {
+	mustReadTestOpenAPIDoc(t, filepath.Join("testdata", "put_create_resource_with_path_param.yml"))
+
+	openAPICtx := &OpenAPIContext{
+		Doc: *testOpenAPIDoc,
+		Pkg: &testPulumiPkg,
+	}
+
+	csharpNamespaces := map[string]string{
+		"": "Provider",
+	}
+
+	_, _, err := openAPICtx.GatherResourcesFromAPI(csharpNamespaces)
+	assert.Nil(t, err)
+
+	subResource, ok := testPulumiPkg.Resources["fake-package:fakeresource/v2:SubResource"]
+	assert.Truef(t, ok, "Expected to find a resource called SubResource: %v", testPulumiPkg.Resources)
+
+	// Ensure that the input properties for the resource contains
+	// the expected id property.
+	assert.Contains(t, subResource.InputProperties, "someId")
+
+	// Ensure that the "get" func also contains the id
+	// as an input properties.
+	getFunc, ok := testPulumiPkg.Functions["fake-package:fakeresource/v2:listSubResources"]
+	assert.Truef(t, ok, "Expected to find a list func listSubResources: %v", testPulumiPkg.Functions)
+	assert.NotNil(t, getFunc.Inputs)
+	assert.Contains(t, getFunc.Inputs.Properties, "someId")
+}

--- a/pkg/testdata/put_create_resource_with_path_param.yml
+++ b/pkg/testdata/put_create_resource_with_path_param.yml
@@ -1,0 +1,58 @@
+openapi: 3.1.0
+info:
+  title: Fake API
+  version: "2.0"
+servers:
+  - url: https://api.fake.com
+    description: production
+
+components:
+  schemas:
+    a_string_prop:
+      type: string
+    request_object_type:
+      type: object
+      properties:
+        simple_prop:
+          $ref: "#/components/schemas/a_string_prop"
+    response_object_type:
+      type: object
+      properties:
+        another_prop:
+          $ref: "#/components/schemas/a_string_prop"
+
+paths:
+  /v2/fakeResource/{some_id}:
+    parameters:
+      - name: some_id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: listSubResources
+      responses:
+        "200":
+          description: The response will be a JSON object with a key called `subResources` which is an array of sub-resource items.
+          content:
+            application/json:
+              schema:
+                properties:
+                  subResources:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/response_object_type"
+    put:
+      operationId: createSubResource
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/request_object_type"
+      responses:
+        "200":
+          description: The response will be a JSON object with a key called `action`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/response_object_type"


### PR DESCRIPTION
# Context

I wanted a Supavisor tenant provider for Pulumi and this seemed like a good solution. Supavisor's API uses a PUT with the id in the path param for the create, so pulschema wouldn't generate any resources.

pulumi-provider-framework actually works fine on create but fails on updates and deletes because it uses the wrong id so I have a PR that fixes that: [PR](https://github.com/cloudy-sky-software/pulumi-provider-framework/pull/409).

The end result is working for me with a local setup I haven't tried publishing it yet: [pulumi-supavisor-native](https://github.com/phillarson-xyz/pulumi-supavisor-native)

# Changes

- Add test for PUT create resource with path parameter
- Add test data YAML file for PUT create resource with path parameter
- Update openapi.go to support PUT create resource with path parameter