### PR TITLE
Naming fixes: "Setting" nouns in operation ID; numbers in property prefixes

### DIFF
--- a/pkg/naming.go
+++ b/pkg/naming.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-var numbersRegexp = regexp.MustCompile("[0-9]+[_]*[a-zA-Z]+")
+var numbersRegexp = regexp.MustCompile("^[0-9]+[_]*[a-zA-Z]+")
 var defaultAllowedPluralResourceNames = []string{"Kubernetes", "Postgres", "Redis"}
 
 // ToSdkName converts a property or attribute name to the lowerCamelCase convention that

--- a/pkg/naming_test.go
+++ b/pkg/naming_test.go
@@ -10,6 +10,7 @@ func TestToSdkName(t *testing.T) {
 	assert.Equal(t, "stringProp", ToSdkName("string_prop"))
 	assert.Equal(t, "stringProp", ToSdkName("string.prop"))
 	assert.Equal(t, "stringPropProp", ToSdkName("string.prop.prop"))
+	assert.Equal(t, "stringProp", ToSdkName("string-prop"))
 }
 
 func TestStartsWithNumber(t *testing.T) {

--- a/pkg/naming_test.go
+++ b/pkg/naming_test.go
@@ -16,4 +16,5 @@ func TestStartsWithNumber(t *testing.T) {
 	assert.True(t, startsWithNumber("1_var"))
 	assert.True(t, startsWithNumber("1var"))
 	assert.False(t, startsWithNumber("var"))
+	assert.False(t, startsWithNumber("var1_var"))
 }

--- a/pkg/resource_naming.go
+++ b/pkg/resource_naming.go
@@ -92,7 +92,7 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 			continue
 		}
 		if operationIDContainsSettings && v == "set" {
-			// placeholder "Setting" (noun) so "set" can be removed
+			// add a placeholder for "Setting" (noun) so "set" can be removed
 			result = strings.ReplaceAll(result, "Setting", "$___$")
 		}
 		result = strings.ReplaceAll(result, v, "")

--- a/pkg/resource_naming.go
+++ b/pkg/resource_naming.go
@@ -72,6 +72,7 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 
 	result := originalOperationID
 	operationIDContainsPostgres := strings.Contains(strings.ToLower(result), postgres)
+	operationIDContainsSettings := strings.Contains(strings.ToLower(result), "setting")
 
 	// TypeSpec-generated operations can have an operation ID separated by the namespace
 	// the operation is defined in.
@@ -90,8 +91,13 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 		if operationIDContainsPostgres && v == "post" {
 			continue
 		}
+		if operationIDContainsSettings && v == "set" {
+			// placeholder "Setting" (noun) so "set" can be removed
+			result = strings.ReplaceAll(result, "Setting", "$___$")
+		}
 		result = strings.ReplaceAll(result, v, "")
 		result = strings.ReplaceAll(result, ToPascalCase(v), "")
+		result = strings.ReplaceAll(result, "$___$", "Setting")
 	}
 
 	resourceTitle := ToPascalCase(result)

--- a/pkg/resource_naming_test.go
+++ b/pkg/resource_naming_test.go
@@ -1,0 +1,15 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetResourceTitleFromOperationID_PUToperationIdWithSetting(t *testing.T) {
+	assert.Equal(t, "TableSetting", getResourceTitleFromOperationID("tableSetting", "PUT", false))
+	assert.Equal(t, "TableSetting", getResourceTitleFromOperationID("table_setting", "PUT", false))
+	assert.Equal(t, "TheTableSetting", getResourceTitleFromOperationID("setTheTableSetting", "PUT", false))
+	assert.Equal(t, "StandardOperationIdName", getResourceTitleFromOperationID("standardOperationIdName", "PUT", false))
+	assert.Equal(t, "TheThing", getResourceTitleFromOperationID("updateTheThing", "PUT", false))
+}


### PR DESCRIPTION
Apologies for the combined pull request, but I figured these fixes are both pretty small.

*Fix 1*: When "Setting" the noun appeared in an operation ID, it was being transformed into "Ting" (dropping the "Set").
e.g.
```
TableSetting -> TableTing
SettingSuperMgmt -> TingSuperMgmt
```
The change below to `pkg/resource_naming.go` fixes this issue.

*Fix 2*: When a number appeared in the first token (before the '_', but not the first character) of a property name, the entire first token was being stripped.

e.g.
```
dhcpdv2_ips -> _ips
ipv6_enabled -> _enabled
```
The change below to `pkg/naming.go` fixes this issue.
