### PR TITLE
fix: allow GET methods with empty response body

### DIFF
--- a/pkg/get_empty_response_body_test.go
+++ b/pkg/get_empty_response_body_test.go
@@ -1,0 +1,41 @@
+package pkg
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEmptyResponseBody(t *testing.T) {
+	mustReadTestOpenAPIDoc(t, filepath.Join("testdata", "get_empty_response_body_openapi.yml"))
+
+	openAPICtx := &OpenAPIContext{
+		Doc: *testOpenAPIDoc,
+		Pkg: &testPulumiPkg,
+	}
+
+	csharpNamespaces := map[string]string{
+		"": "Provider",
+	}
+
+	providerMetadata, _, err := openAPICtx.GatherResourcesFromAPI(csharpNamespaces)
+	assert.Nil(t, err)
+	assert.NotNil(t, providerMetadata)
+
+	// GET with JSON response should be a function.
+	_, ok := testPulumiPkg.Functions[packageName+":vms/v2:getVm"]
+	assert.True(t, ok, "Expected to find function getVm in the Pulumi package spec")
+
+	// GET with no response body (ad-hoc restart action) should also be a function.
+	_, ok = testPulumiPkg.Functions[packageName+":vms/v2:getVmsRestart"]
+	assert.True(t, ok, "Expected to find function getVmsRestart for ad-hoc GET action with no response body")
+
+	// The ad-hoc action function should have no return type.
+	restartFunc := testPulumiPkg.Functions[packageName+":vms/v2:getVmsRestart"]
+	assert.Nil(t, restartFunc.ReturnType, "Expected ad-hoc GET action to have no return type")
+
+	// List with JSON response should be a function.
+	_, ok = testPulumiPkg.Functions[packageName+":vms/v2:listVms"]
+	assert.True(t, ok, "Expected to find function listVms in the Pulumi package spec")
+}

--- a/pkg/openapi.go
+++ b/pkg/openapi.go
@@ -207,15 +207,22 @@ func (o *OpenAPIContext) GatherResourcesFromAPI(csharpNamespaces map[string]stri
 
 			glog.V(3).Infof("GET: Parent path for %s is %s\n", currentPath, parentPath)
 
-			respType := pathItem.Get.Responses.Status(200).Value.Content.Get(jsonMimeType)
-			// IF the JSON mime type is not defined, try to check for the text/plain
-			// response type.
-			if respType == nil || respType.Schema == nil || respType.Schema.Value == nil {
-				respType = pathItem.Get.Responses.Status(200).Value.Content.Get(plainTextMimeType)
+			// GET endpoints may not have a response body at all.
+			// For example, ad-hoc actions like restarting a VM or
+			// initiating a backup may return 204 No Content.
+			var respType *openapi3.MediaType
+			statusOkResp := pathItem.Get.Responses.Status(200)
+			if statusOkResp != nil && statusOkResp.Value != nil && statusOkResp.Value.Content != nil {
+				respType = statusOkResp.Value.Content.Get(jsonMimeType)
+				// If the JSON mime type is not defined, try to check for the text/plain
+				// response type.
 				if respType == nil || respType.Schema == nil || respType.Schema.Value == nil {
-					// Create an empty response type.
-					respType = openapi3.NewMediaType().WithSchema(defaultEmptySchemaDoNotMutate)
+					respType = statusOkResp.Value.Content.Get(plainTextMimeType)
 				}
+			}
+			if respType == nil || respType.Schema == nil || respType.Schema.Value == nil {
+				// Create an empty response type.
+				respType = openapi3.NewMediaType().WithSchema(defaultEmptySchemaDoNotMutate)
 			}
 
 			setReadOperationMapping := func(tok string) {

--- a/pkg/testdata/get_empty_response_body_openapi.yml
+++ b/pkg/testdata/get_empty_response_body_openapi.yml
@@ -1,0 +1,110 @@
+openapi: 3.1.0
+info:
+  title: Fake API
+  version: "2.0"
+servers:
+  - url: https://api.fake.com
+    description: production
+
+components:
+  schemas:
+    vm:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique identifier for the VM.
+        name:
+          type: string
+          description: The name of the VM.
+        status:
+          type: string
+          description: The current status of the VM.
+      required:
+        - id
+        - name
+    vm_list_response:
+      type: object
+      properties:
+        vms:
+          type: array
+          items:
+            $ref: "#/components/schemas/vm"
+
+  parameters:
+    vm_id:
+      description: The VM ID
+      in: path
+      name: vm_id
+      required: true
+      schema:
+        type: string
+      example: vm-123
+
+  responses:
+    no_content:
+      description: The action was successful. No content returned.
+    get_vm:
+      description: A JSON object with the VM details.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/vm"
+    list_vms:
+      description: A JSON object with a list of VMs.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/vm_list_response"
+
+paths:
+  /v2/vms:
+    post:
+      operationId: vms_create
+      summary: Create a VM
+      tags:
+        - VMs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/vm"
+      responses:
+        "201":
+          $ref: "#/components/responses/get_vm"
+
+    get:
+      operationId: vms_list
+      summary: List all VMs
+      tags:
+        - VMs
+      responses:
+        "200":
+          $ref: "#/components/responses/list_vms"
+
+  /v2/vms/{vm_id}:
+    get:
+      operationId: vms_get
+      summary: Get a VM
+      tags:
+        - VMs
+      parameters:
+        - $ref: "#/components/parameters/vm_id"
+      responses:
+        "200":
+          $ref: "#/components/responses/get_vm"
+
+  /v2/vms/{vm_id}/restart:
+    get:
+      operationId: vms_restart
+      summary: Restart a VM
+      description: >-
+        Initiates a restart of the specified VM. This is an ad-hoc
+        action that does not return a response body.
+      tags:
+        - VMs
+      parameters:
+        - $ref: "#/components/parameters/vm_id"
+      responses:
+        "204":
+          $ref: "#/components/responses/no_content"


### PR DESCRIPTION
Fix nil pointer dereference in GET endpoint response handling when the endpoint has no 200 response or no response body content. GET endpoints may not have a response body because some cloud providers implement ad-hoc actions (e.g. restarting a VM, initiating a backup) as GET endpoints.

Closes #338

Generated with [Claude Code](https://claude.ai/claude-code)