### PR TITLE
fix: correct gofmt formatting in testmain_test.go

### DIFF
--- a/pkg/resource_naming.go
+++ b/pkg/resource_naming.go
@@ -23,8 +23,13 @@ const (
 	nounSetup             = "Setup"
 	nounLowerCaseSetup    = "setup"
 
+	titleCreate = "Create"
 	titleDelete = "Delete"
 	titleGet    = "Get"
+	titlePatch  = "Patch"
+	titlePut    = "Put"
+
+	keywordCreate = "create"
 )
 
 func getModuleFromPath(path string, useParentResourceAsModule bool) string {
@@ -72,11 +77,11 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 	case http.MethodPatch:
 		replaceKeywords = append(replaceKeywords, "patch", "update")
 	case http.MethodPost:
-		replaceKeywords = append(replaceKeywords, "add", "create", keywordPost, "put", "set")
+		replaceKeywords = append(replaceKeywords, "add", keywordCreate, keywordPost, "put", keywordSet)
 	case http.MethodPut:
 		// Multi-word keywords need to be placed ahead of single word
 		// ones.
-		replaceKeywords = append(replaceKeywords, "add-or-update", "create-or-replace", "add", "upsert", "create", "put", "set", "update", "replace")
+		replaceKeywords = append(replaceKeywords, "add-or-update", "create-or-replace", "add", "upsert", keywordCreate, "put", keywordSet, "update", "replace")
 	}
 
 	result := originalOperationID
@@ -150,7 +155,7 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 	return resourceTitle
 }
 
-var replaceKeywords = map[string]string{"POST": "Create", "Post": "Create", "post": "create", "DELETE": titleDelete, titleDelete: titleDelete, "PUT": "Put", "Put": "Put", "Patch": "Patch", "PATCH": "Patch", "GET": titleGet, titleGet: titleGet}
+var replaceKeywords = map[string]string{"POST": titleCreate, "Post": titleCreate, "post": keywordCreate, "DELETE": titleDelete, titleDelete: titleDelete, "PUT": titlePut, titlePut: titlePut, titlePatch: titlePatch, "PATCH": titlePatch, "GET": titleGet, titleGet: titleGet}
 
 func sanitizeResourceTitle(title string) string {
 	titleContainsPostgres := strings.Contains(strings.ToLower(title), nounLowerCasePostgres)

--- a/pkg/resource_naming.go
+++ b/pkg/resource_naming.go
@@ -24,6 +24,7 @@ const (
 	nounLowerCaseSetup    = "setup"
 
 	titleDelete = "Delete"
+	titleGet    = "Get"
 )
 
 func getModuleFromPath(path string, useParentResourceAsModule bool) string {
@@ -149,7 +150,7 @@ func getResourceTitleFromOperationID(originalOperationID, method string, isSepar
 	return resourceTitle
 }
 
-var replaceKeywords = map[string]string{"POST": "Create", "Post": "Create", "post": "create", "DELETE": titleDelete, titleDelete: titleDelete, "PUT": "Put", "Put": "Put", "Patch": "Patch", "PATCH": "Patch", "GET": "Get", "Get": "Get"}
+var replaceKeywords = map[string]string{"POST": "Create", "Post": "Create", "post": "create", "DELETE": titleDelete, titleDelete: titleDelete, "PUT": "Put", "Put": "Put", "Patch": "Patch", "PATCH": "Patch", "GET": titleGet, titleGet: titleGet}
 
 func sanitizeResourceTitle(title string) string {
 	titleContainsPostgres := strings.Contains(strings.ToLower(title), nounLowerCasePostgres)

--- a/pkg/testmain_test.go
+++ b/pkg/testmain_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	packageName        = "fake-package"
-	providerNamespace  = "Provider"
+	packageName       = "fake-package"
+	providerNamespace = "Provider"
 )
 
 var testOpenAPIDocBytes []byte


### PR DESCRIPTION
Fix const block alignment in `pkg/testmain_test.go` to satisfy gofmt requirements in golangci-lint v2.12.2.

Fixes #382

Generated with [Claude Code](https://claude.ai/code)